### PR TITLE
Refactor panel to use CSV credit values and split revenue

### DIFF
--- a/panel_escenarios_wm.py
+++ b/panel_escenarios_wm.py
@@ -1,6 +1,7 @@
 import streamlit as st
 import pandas as pd
 import numpy as np
+import os
 
 st.set_page_config(page_title="Modelo financiero — Escenarios", layout="wide")
 st.title("Modelo financiero — Escenarios")
@@ -9,10 +10,7 @@ st.title("Modelo financiero — Escenarios")
 #  CARGA DE DATOS
 # =========================
 st.sidebar.header("Carga de datos")
-src = st.sidebar.radio("Fuente", ["Usar BASE_ANALISI2024.csv", "Subir otro CSV"])
-
-# Ruta por defecto en TU Windows (ajústala si cambias la carpeta)
-PATH_WIN_DEFAULT = r"C:\Users\Nitro\Downloads\AAAAAAAA\Proyecto modelo financiero\BASE_ANALISI2024.csv"
+src = st.sidebar.radio("Fuente", ["Ruta local", "Subir CSV"])
 
 def load_csv_semicolon(path_or_buf):
     """Primero intenta ; fijo. Si falla, intenta autodetección."""
@@ -22,14 +20,17 @@ def load_csv_semicolon(path_or_buf):
         pass
     return pd.read_csv(path_or_buf, sep=None, engine="python")
 
-if src == "Usar BASE_ANALISI2024.csv":
-    path = st.sidebar.text_input("Ruta CSV (;)", PATH_WIN_DEFAULT)
-    path = path.strip().strip('"')  # por si Windows pega comillas
-    try:
-        df = load_csv_semicolon(path)
-    except FileNotFoundError:
+if src == "Ruta local":
+    path = st.sidebar.text_input("Ruta CSV (;)", "")
+    path = path.strip().strip('"')
+    if not path:
+        st.info("Ingresa la ruta del CSV para continuar…")
+        st.stop()
+    if not os.path.exists(path):
         st.error("No encuentro el archivo en esa ruta. Verifica la ruta exacta.")
         st.stop()
+    try:
+        df = load_csv_semicolon(path)
     except Exception as e:
         st.error(f"No pude leer el CSV: {e}")
         st.stop()
@@ -76,21 +77,32 @@ col_est         = select_col("Est (ponderador 0–1)", ["est"], exclude=excluir_
 col_planta      = select_col("Planta (ponderador 0–1)", ["planta"], exclude=excluir_ponderadores)
 col_comp        = select_col("Comp (ponderador 0–1)", ["comp"], exclude=excluir_ponderadores)
 col_tipo        = select_col("Tipo (ponderador 0–1)", ["tipo"], exclude=excluir_ponderadores)
-
-col_promcred    = select_col("PromdeCreditos", ["prom","credito","crédito"], exclude=[col_num_est])
-col_matr_actual = select_col("MATR.ACTUAL", ["matr","actual","matrícula","matricula","costo/actual"], exclude=[col_num_est])
+col_promcred    = select_col("PromdeCreditos", ["prom"], exclude=[col_num_est])
+col_matricula   = select_col("MATRÍCULA", ["matr","matríc","matricu"], exclude=[col_num_est])
+col_matr_actual = select_col(
+    "MATR.ACTUAL (MATRÍCULA * salario mínimo)",
+    ["matr","actual","matrícula","matricula","costo/actual"],
+    exclude=[col_num_est, col_matricula],
+)
+col_valor_cred  = select_col(
+    "Valor crédito",
+    ["valor", "crédito", "credito"],
+    exclude=[col_num_est, col_promcred, col_matr_actual, col_matricula],
+)
 
 # Validación final
 required = [
     col_programa, col_nivel, col_modalidad, col_est, col_planta, col_comp,
-    col_tipo, col_promcred, col_matr_actual, col_num_est
+    col_tipo, col_promcred, col_matricula, col_matr_actual, col_valor_cred,
+    col_num_est,
 ]
 if any(c is None for c in required):
     st.error("Faltan columnas requeridas (elige todas en el mapeo del panel lateral).")
     st.stop()
 
-if col_est == col_num_est or col_planta == col_num_est or col_comp == col_num_est or col_tipo == col_num_est:
-    st.error(f"Est/Planta/Comp/Tipo NO pueden ser la columna '{col_num_est}'. Corrige el mapeo en la barra lateral.")
+finance_cols = [col_promcred, col_matricula, col_matr_actual, col_valor_cred]
+if col_num_est in finance_cols or col_est == col_num_est or col_planta == col_num_est or col_comp == col_num_est or col_tipo == col_num_est:
+    st.error(f"Revisa el mapeo: ninguna columna financiera ni ponderador puede ser '{col_num_est}'.")
     st.stop()
 
 with st.expander("Mapeo actual"):
@@ -103,24 +115,15 @@ with st.expander("Mapeo actual"):
         "Comp": col_comp,
         "Tipo": col_tipo,
         "PromdeCreditos": col_promcred,
+        "MATRÍCULA": col_matricula,
         "MATR.ACTUAL": col_matr_actual,
+        "Valor crédito": col_valor_cred,
         "N-EST": col_num_est,
     })
-
+ 
 # =========================
 #  PARÁMETROS DEL MODELO
 # =========================
-st.sidebar.header("Base por nivel (COP)")
-base_doc = st.sidebar.number_input("Doctorado",        0, 10_000_000, 900_000, step=10_000)
-base_ma  = st.sidebar.number_input("Maestría",         0, 10_000_000, 630_000, step=10_000)
-base_esp = st.sidebar.number_input("Especialización",  0, 10_000_000, 450_000, step=10_000)
-
-st.sidebar.header("Multiplicadores por modalidad")
-mult_pres = st.sidebar.number_input("PRESENCIAL",        0.0, 5.0, 1.00, step=0.05)
-mult_hib  = st.sidebar.number_input("HIBRIDO / HÍBRIDO", 0.0, 5.0, 0.85, step=0.05)
-mult_virt = st.sidebar.number_input("VIRTUAL",           0.0, 5.0, 0.70, step=0.05)
-mult_mq   = st.sidebar.number_input("MEDICOQUIRURGICA (si la usas como modalidad)", 0.0, 5.0, 1.00, step=0.05)
-
 st.sidebar.header("Créditos mínimos y mezcla por nivel")
 min_doc = st.sidebar.number_input("Mín. créditos Doctorado", 0, 40, 8); pmin_doc = st.sidebar.slider("% Doc en mínimos", 0, 100, 0) / 100
 min_ma  = st.sidebar.number_input("Mín. créditos Maestría",  0, 40, 7); pmin_ma  = st.sidebar.slider("% Mtr en mínimos", 0, 100, 30) / 100
@@ -157,33 +160,30 @@ def to_number_series(series):
 # =========================
 #  FUNCIONES DEL MODELO
 # =========================
-def base_nivel(n):
-    s = str(n).strip().lower()
-    if "doctor" in s: return base_doc
-    if "maestr" in s: return base_ma
-    if "espec"  in s: return base_esp
-    return base_ma  # neutral
-
 def mult_modalidad(m):
     s = str(m).strip().lower()
-    if "pres"   in s: return mult_pres
-    if "hib"    in s or "íbr" in s or "hí" in s: return mult_hib
-    if "virt"   in s: return mult_virt
-    if "medico" in s or "médico" in s: return mult_mq   # MEDICOQUIRURGICA como modalidad
-    return mult_pres
+    if "virt" in s:   return 0.70
+    if "hib" in s or "íbr" in s or "hí" in s: return 0.85
+    if "medico" in s or "médico" in s: return 1.0
+    return 1.0
 
-def mix_credits(nivel, prom):
+def split_estudiantes(nivel, prom, n_est):
     s = str(nivel).strip().lower()
     if "doctor" in s:
         norm = norm_doc if norm_doc > 0 else prom
-        return pmin_doc*min_doc + (1-pmin_doc)*norm
+        n_min = n_est * pmin_doc
+        return n_min, n_est - n_min, min_doc, norm
     if "maestr" in s:
         norm = norm_ma if norm_ma > 0 else prom
-        return pmin_ma*min_ma + (1-pmin_ma)*norm
+        n_min = n_est * pmin_ma
+        return n_min, n_est - n_min, min_ma, norm
     if "espec" in s:
         norm = norm_esp if norm_esp > 0 else prom
-        return pmin_esp*min_esp + (1-pmin_esp)*norm
-    return prom
+        n_min = n_est * pmin_esp
+        return n_min, n_est - n_min, min_esp, norm
+    norm = norm_ma if norm_ma > 0 else prom
+    n_min = n_est * pmin_ma
+    return n_min, n_est - n_min, min_ma, norm
 
 # =========================
 #  CÁLCULO (SIN TOCAR TU CSV)
@@ -195,19 +195,25 @@ Planta  = to_number_series(df_calc[col_planta]).fillna(0)
 Comp    = to_number_series(df_calc[col_comp]).fillna(0)
 Tipo    = to_number_series(df_calc[col_tipo]).fillna(0)
 PromCr  = to_number_series(df_calc[col_promcred]).fillna(0)
-MatrAct = to_number_series(df_calc[col_matr_actual]).fillna(0)
-NEst    = to_number_series(df_calc[col_num_est]).fillna(0)
+MatrBase = to_number_series(df_calc[col_matricula]).fillna(0)
+MatrAct  = to_number_series(df_calc[col_matr_actual]).fillna(0)
+ValorCredBase = to_number_series(df_calc[col_valor_cred]).fillna(0)
+NEst     = to_number_series(df_calc[col_num_est]).fillna(0)
 
-df_calc["valor_credito_modelo"]    = df_calc[col_nivel].apply(base_nivel) * df_calc[col_modalidad].apply(mult_modalidad)
-df_calc["valor_credito_programa"]  = df_calc["valor_credito_modelo"] * (0.35*Est + 0.35*Planta + 0.2*Comp + 0.1*Tipo)
-df_calc["creditos_prom_escenario"] = [mix_credits(n, p) for n, p in zip(df_calc[col_nivel], PromCr)]
-df_calc["MATR.NUEVA_CALC"]         = df_calc["valor_credito_programa"] * df_calc["creditos_prom_escenario"]
+df_calc["valor_credito_modelo"]   = ValorCredBase * df_calc[col_modalidad].apply(mult_modalidad)
+df_calc["valor_credito_programa"] = df_calc["valor_credito_modelo"] * (0.35*Est + 0.35*Planta + 0.2*Comp + 0.1*Tipo)
 
-# Recaudos EXACTOS
+split_vals = [split_estudiantes(n, p, ne) for n, p, ne in zip(df_calc[col_nivel], PromCr, NEst)]
+split_df = pd.DataFrame(split_vals, columns=["NEst_min","NEst_norm","Cred_min","Cred_norm"], index=df_calc.index)
+df_calc = pd.concat([df_calc, split_df], axis=1)
+
+df_calc["MATR.NUEVA_min"]  = df_calc["valor_credito_programa"] * df_calc["Cred_min"]
+df_calc["MATR.NUEVA_norm"] = df_calc["valor_credito_programa"] * df_calc["Cred_norm"]
 df_calc["Recaudo_actual"] = NEst * MatrAct
-df_calc["Recaudo_nuevo"]  = NEst * df_calc["MATR.NUEVA_CALC"]
+df_calc["Recaudo_nuevo"]  = df_calc["NEst_min"] * df_calc["MATR.NUEVA_min"] + df_calc["NEst_norm"] * df_calc["MATR.NUEVA_norm"]
+df_calc["MATR.NUEVA_CALC"] = np.where(NEst == 0, 0, df_calc["Recaudo_nuevo"] / NEst)
 df_calc["Delta_recaudo"]  = df_calc["Recaudo_nuevo"] - df_calc["Recaudo_actual"]
-df_calc["Delta_recaudo_%"]= np.where(df_calc["Recaudo_actual"] == 0, 0, df_calc["Delta_recaudo"] / df_calc["Recaudo_actual"])
+df_calc["Delta_recaudo_%"] = np.where(df_calc["Recaudo_actual"] == 0, 0, df_calc["Delta_recaudo"] / df_calc["Recaudo_actual"])
 
 # =========================
 #  MÉTRICAS Y VISTAS
@@ -228,6 +234,12 @@ with st.expander("Control rápido (5 filas): N-EST * MATR.ACTUAL y MATR.NUEVA_CA
     tmp["calc_nuevo"]  = to_number_series(tmp[col_num_est]) * tmp["MATR.NUEVA_CALC"]
     st.dataframe(tmp)
 
+with st.expander("Detalle de mezcla de créditos y recaudo"):
+    st.dataframe(df_calc[[
+        col_programa, col_nivel, "NEst_min", "Cred_min", "NEst_norm", "Cred_norm",
+        "MATR.NUEVA_min", "MATR.NUEVA_norm", "Recaudo_nuevo"
+    ]])
+
 st.subheader("Resumen por nivel")
 by_level = df_calc.groupby(df_calc[col_nivel]).agg(
     rec_actual=("Recaudo_actual", "sum"),
@@ -236,12 +248,15 @@ by_level = df_calc.groupby(df_calc[col_nivel]).agg(
 by_level["delta"]   = by_level["rec_nuevo"] - by_level["rec_actual"]
 by_level["delta_%"] = np.where(by_level["rec_actual"] == 0, 0, by_level["delta"] / by_level["rec_actual"])
 st.dataframe(by_level, use_container_width=True)
+st.bar_chart(by_level.set_index(col_nivel)[["rec_actual", "rec_nuevo"]])
 
 st.subheader("Programas: Top ± impacto (Δ Recaudo)")
 df_sorted = df_calc[[col_programa, col_nivel, "Recaudo_actual", "Recaudo_nuevo", "Delta_recaudo", "Delta_recaudo_%"]]\
     .sort_values("Delta_recaudo", ascending=False)
 st.dataframe(df_sorted.head(20), use_container_width=True)
 st.dataframe(df_sorted.tail(20).sort_values("Delta_recaudo", ascending=True), use_container_width=True)
+top_prog = df_sorted.head(10)[[col_programa, "Recaudo_actual", "Recaudo_nuevo"]].set_index(col_programa)
+st.bar_chart(top_prog)
 
 # =========================
 #  DESCARGA CSV CON ';'


### PR DESCRIPTION
## Summary
- Allow loading data from a user supplied CSV path or file upload
- Map financial columns explicitly, including base credit value and matricula
- Recalculate revenue by splitting students into minimum and normal credit groups and visualize results

## Testing
- `python -m py_compile panel_escenarios_wm.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68a60387064083279f0069d8011bf9c6