### PR TITLE
Fix selection hint for MATR.ACTUAL column

### DIFF
--- a/panel_escenarios_wm.py
+++ b/panel_escenarios_wm.py
@@ -81,7 +81,7 @@ col_promcred    = select_col("PromdeCreditos", ["prom"], exclude=[col_num_est])
 col_matricula   = select_col("MATRÍCULA", ["matr","matríc","matricu"], exclude=[col_num_est])
 col_matr_actual = select_col(
     "MATR.ACTUAL (MATRÍCULA * salario mínimo)",
-    ["matr","actual","matrícula","matricula","costo/actual"],
+    ["matr","actual","matrícula","matricula"],
     exclude=[col_num_est, col_matricula],
 )
 col_valor_cred  = select_col(


### PR DESCRIPTION
## Summary
- remove `costo/actual` hint so the interface only suggests the correct `MATR.ACTUAL` column from the CSV

## Testing
- `python -m py_compile panel_escenarios_wm.py`


------
https://chatgpt.com/codex/tasks/task_e_68a60b7fbe048327956feb9c6fa539ef